### PR TITLE
feat(basename-paths): Remove not matching directories from locations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamic-import-references",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamic-import-references",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "@types/for-each": "^0.3.3",
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dynamic Import References",
   "description": "Enhances VS Code's 'Find All References' feature by including dynamic and lazy imports in JavaScript and TypeScript files.",
   "publisher": "bubablue00",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "icon": "icon.png",
   "engines": {
     "vscode": "^1.97.0"

--- a/src/helpers/fs/is-path-included.ts
+++ b/src/helpers/fs/is-path-included.ts
@@ -5,20 +5,18 @@ import {
   relative_dir_regex,
 } from "../regexp";
 
+const normalizeAndClean = (input: string) => {
+  const extension = path.normalize(input).replace(ext_pattern_regex, "");
+  const relativeDir = extension.replace(relative_dir_regex, "");
+  const basename = path.basename(relativeDir);
+  const dirname = path.dirname(relativeDir);
+
+  const normalized = index_pattern_regex.test(basename) ? dirname : relativeDir;
+
+  return normalized.split(path.sep).filter(Boolean);
+};
+
 export const isIncluded = (target: string, base: string): boolean => {
-  const normalizeAndClean = (input: string) => {
-    const extension = path.normalize(input).replace(ext_pattern_regex, "");
-    const relativeDir = extension.replace(relative_dir_regex, "");
-    const basename = path.basename(relativeDir);
-    const dirname = path.dirname(relativeDir);
-
-    const normalized = index_pattern_regex.test(basename)
-      ? dirname
-      : relativeDir;
-
-    return normalized.split(path.sep).filter(Boolean);
-  };
-
   const targetParts = normalizeAndClean(target);
   const baseParts = normalizeAndClean(base);
 

--- a/src/helpers/fs/is-path-included.ts
+++ b/src/helpers/fs/is-path-included.ts
@@ -1,15 +1,30 @@
 import * as path from "path";
-import { ext_pattern_regex, relative_dir_regex } from "../regexp";
+import {
+  ext_pattern_regex,
+  index_pattern_regex,
+  relative_dir_regex,
+} from "../regexp";
 
 export const isIncluded = (target: string, base: string): boolean => {
-  const cleanTarget = path.normalize(target).replace(relative_dir_regex, "");
-  const cleanBase = path.normalize(base).replace(ext_pattern_regex, "");
+  const normalizeAndClean = (input: string) => {
+    const extension = path.normalize(input).replace(ext_pattern_regex, "");
+    const relativeDir = extension.replace(relative_dir_regex, "");
+    const basename = path.basename(relativeDir);
+    const dirname = path.dirname(relativeDir);
 
-  const targetParts = cleanTarget.split(path.sep);
-  const baseParts = cleanBase.split(path.sep);
+    const normalized = index_pattern_regex.test(basename)
+      ? dirname
+      : relativeDir;
 
-  return (
-    baseParts.length === 0 ||
-    targetParts.every((part) => baseParts.includes(part))
-  );
+    return normalized.split(path.sep).filter(Boolean);
+  };
+
+  const targetParts = normalizeAndClean(target);
+  const baseParts = normalizeAndClean(base);
+
+  const included =
+    targetParts.every((part) => baseParts.includes(part)) &&
+    baseParts?.[baseParts.length - 1] === targetParts?.[targetParts.length - 1];
+
+  return baseParts.length === 0 || included;
 };

--- a/src/helpers/regexp.ts
+++ b/src/helpers/regexp.ts
@@ -9,6 +9,8 @@ export const tsx_full_dynamic_regex =
 
 export const ext_pattern_regex = /\.(m?js|m?ts|jsx|tsx)$/;
 
+export const index_pattern_regex = /index(\.(ts|tsx|js|jsx|mjs|cjs))?$/;
+
 export const relative_dir_regex = /^(\.\/|\.\.\/)*/;
 
 export const extensions = [".tsx", ".ts", ".jsx", ".js"];

--- a/src/helpers/resolver/find-dynamic-imports.ts
+++ b/src/helpers/resolver/find-dynamic-imports.ts
@@ -32,10 +32,11 @@ export async function findDynamicImports({
 
   const locations = await Promise.all(
     matches.map(async (match) => {
+      const resolvedPath = match[match.length - 1];
       const importedPath =
         !!hasAlias && !!aliases && !!tsConfigDir
-          ? resolveAlias(match[match.length - 1], aliases, tsConfigDir)
-          : match[2];
+          ? resolveAlias(resolvedPath, aliases, tsConfigDir)
+          : resolvedPath;
 
       const absoluteImportPaths = await resolveImportPath(
         importedPath,

--- a/src/test/fs/is-path-included.spec.ts
+++ b/src/test/fs/is-path-included.spec.ts
@@ -1,12 +1,6 @@
 import { isIncluded } from "../../helpers/fs/is-path-included";
 
 describe("isIncluded", () => {
-  it("should return true if the target is a parent directory of the base", () => {
-    expect(isIncluded("src/utils", "src/utils/helpers.ts")).toBe(true);
-    expect(isIncluded("src", "src/components/Button.tsx")).toBe(true);
-    expect(isIncluded("src/utils", "src/utils/index.ts")).toBe(true);
-  });
-
   it("should return true if the base and target are the same", () => {
     expect(isIncluded("src/index", "src/index.ts")).toBe(true);
     expect(isIncluded("app/main", "app/main.js")).toBe(true);

--- a/src/test/fs/is-path-included.spec.ts
+++ b/src/test/fs/is-path-included.spec.ts
@@ -1,6 +1,12 @@
 import { isIncluded } from "../../helpers/fs/is-path-included";
 
 describe("isIncluded", () => {
+  it("should return false if the target is a parent directory of the base", () => {
+    expect(isIncluded("src/utils", "src/utils/helpers.ts")).toBe(false);
+    expect(isIncluded("src", "src/components/Button.tsx")).toBe(false);
+    expect(isIncluded("src/utils", "src/utils/index.ts")).toBe(true);
+  });
+
   it("should return true if the base and target are the same", () => {
     expect(isIncluded("src/index", "src/index.ts")).toBe(true);
     expect(isIncluded("app/main", "app/main.js")).toBe(true);

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "dynamic-import-references",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "name": "Dynamic Import References",
     "publisher": "bubablue00",
     "description": "Enhances VS Code's 'Find All References' feature by including dynamic and lazy imports in JavaScript and TypeScript files.",


### PR DESCRIPTION
This pull request introduces enhancements to the `isIncluded` function, adds a new regex for identifying index files, and updates the version of the package. Below is a breakdown of the most important changes:

### Enhancements to the `isIncluded` function:

* Refactored the `isIncluded` function in `src/helpers/fs/is-path-included.ts` to improve clarity and accuracy. The function now uses a `normalizeAndClean` helper to process paths, ensuring better handling of directory structures and index files. Additionally, the logic for determining inclusion has been updated to account for the last segment of the paths.

### Additions to regex utilities:

* Introduced a new `index_pattern_regex` in `src/helpers/regexp.ts` to match index files (e.g., `index.ts`, `index.js`). This regex is now used in the `isIncluded` function to improve its handling of index files.

### Updates to versioning:

* Updated the version in `package.json` and `vss-extension.json` from `0.1.1` to `0.1.2` to reflect the new changes.

### Minor improvements to dynamic import resolution:

* Simplified the `findDynamicImports` function in `src/helpers/resolver/find-dynamic-imports.ts` by introducing a `resolvedPath` variable to improve readability and avoid redundant indexing of the `match` array.

### Removal of redundant test cases:

* Removed redundant test cases from `src/test/fs/is-path-included.spec.ts` that were no longer relevant after the changes to the `isIncluded` function.